### PR TITLE
[fix] 중복 검사 api 결과 반환 수정 및 header-token 이름 변경

### DIFF
--- a/src/mocks/duplicateHandlers.ts
+++ b/src/mocks/duplicateHandlers.ts
@@ -10,13 +10,13 @@ export const duplicateHandlers = [
     const query = url.searchParams.get("query");
     console.log("중복 검사", type, query);
 
-    if (!DuplicateMockData[type].includes(query)) {
-      return HttpResponse.json(false, {
+    if (DuplicateMockData[type].includes(query)) {
+      return HttpResponse.json(true, {
         status: 409,
       });
     }
 
-    return HttpResponse.json(true, {
+    return HttpResponse.json(false, {
       status: 201,
     });
   }),

--- a/src/mocks/userHandlers.ts
+++ b/src/mocks/userHandlers.ts
@@ -55,7 +55,7 @@ export const userHandlers = [
           },
           {
             headers: {
-              authtoken: "abc-123",
+              access: "abc-123",
               "Set-Cookie": "refresh=abc-123",
             },
           },
@@ -69,7 +69,7 @@ export const userHandlers = [
   // 로그아웃
   http.post("/logout", async ({ cookies }) => {
     console.log("logout");
-    if (cookies.authToken) return HttpResponse.json({}, { status: 201 });
+    if (cookies.access) return HttpResponse.json({}, { status: 201 });
     return HttpResponse.json(
       {
         result: "SUCCESS",


### PR DESCRIPTION
## Background
[fix] 중복 검사 api 결과 반환 수정 및 header-token 이름 변경

## Details
- duplicateHandlers
반환인 true, false가 반대로 설정되어 수정

- userHandlers
token 이름 변경 (authtoken -> access)

## Discuss


## UI Images