### PR TITLE
[fix] API_URL .env 파일에 저장

### DIFF
--- a/src/Utils/apiFetch.ts
+++ b/src/Utils/apiFetch.ts
@@ -1,12 +1,10 @@
 import axios, { AxiosError } from "axios";
 
 // 추후 변경
-const API_BASE_URL = "https://example.com/api";
 const API_TOKEN = localStorage.getItem("USER_ID");
 
 const axiosInstance = axios.create({
-  // baseURL: API_BASE_URL,
-  baseURL: "",
+  baseURL: import.meta.env.REACT_API_BASE_URL,
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import App from "./App.tsx";
 
 async function deferRender() {
   if (process.env.NODE_ENV !== "development") return;
+  if (import.meta.env.REACT_API_BASE_URL !== "") return;
 
   const { worker } = await import("./mocks/browser");
 


### PR DESCRIPTION
## Background
 API_URL .env 파일에 저장

## Details
- src/Utils/apiFetch.ts
url 호출 방법 변경

- src/main.tsx
.env에 저장된 url이 ""이 아니면 mock API를 사용하지 않게 변경


## Discuss


## UI Images