### PR TITLE
[feat] 재발급 토큰 api 및 토큰 전역상태로 관리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import "./App.css";
+import { useEffect } from "react";
 import { BrowserRouter } from "react-router-dom";
 import Router from "./Router/routes";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { useAuthStore } from "./store/authStore";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,6 +16,14 @@ const queryClient = new QueryClient({
 });
 
 function App() {
+  const { accessToken, startTokenRefresh } = useAuthStore();
+
+  useEffect(() => {
+    if (accessToken) {
+      startTokenRefresh();
+    }
+  }, [accessToken, startTokenRefresh]);
+
   return (
     <>
       <QueryClientProvider client={queryClient}>

--- a/src/Components/SignInForm.tsx
+++ b/src/Components/SignInForm.tsx
@@ -7,6 +7,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import fetchCall from "../Utils/apiFetch";
 import { STORAGE_KEYS } from "../Constants/STORAGE_KEYS";
+import { useAuthStore } from "../store/authStore";
 
 const schema = z.object({
   email: z
@@ -52,6 +53,8 @@ const SignIn = (): JSX.Element => {
     reValidateMode: "onSubmit", // 재검증도 제출 시에만
   });
 
+  const setAccessToken = useAuthStore(state => state.setAccessToken);
+
   const onSubmit: SubmitHandler<Inputs> = async data => {
     try {
       const response = await fetchCall<LoginResponseHeaders>("/login", "post", {
@@ -68,13 +71,14 @@ const SignIn = (): JSX.Element => {
         console.log("로그인 성공:", response.data);
 
         // LocalStorage에 정보 저장
-        localStorage.setItem(STORAGE_KEYS.TOKEN, accessToken);
+        // localStorage.setItem(STORAGE_KEYS.TOKEN, accessToken);
+        setAccessToken(accessToken);
         localStorage.setItem(STORAGE_KEYS.USER_ID, String(responseData.id));
         localStorage.setItem(
           STORAGE_KEYS.PROFILE_CHECK,
           String(responseData.profileCheck),
         );
-
+        
         if (responseData?.profileCheck) {
           window.location.href = "/";
         } else {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,48 @@
+import { create } from "zustand";
+import fetchCall from "../Utils/apiFetch";
+import { STORAGE_KEYS } from "../Constants/STORAGE_KEYS";
+
+interface AuthState {
+  accessToken: string | null;
+  setAccessToken: (token: string | null) => void;
+  startTokenRefresh: () => void;
+}
+
+export const useAuthStore = create<AuthState>(set => ({
+  accessToken: localStorage.getItem(STORAGE_KEYS.TOKEN),
+  setAccessToken: token => {
+    if (token) {
+      localStorage.setItem(STORAGE_KEYS.TOKEN, token);
+    } else {
+      localStorage.removeItem(STORAGE_KEYS.TOKEN);
+    }
+    set({ accessToken: token });
+  },
+  startTokenRefresh: () => {
+    const TOKEN_REFRESH_INTERVAL = 29 * 60 * 1000; // 29분
+
+    setInterval(async () => {
+      try {
+        const response = await fetchCall<{
+          headers: { access: string };
+        }>("/api/v1/users/reissue", "post");
+
+        const newAccessToken = response.headers.access;
+        if (newAccessToken) {
+          set({ accessToken: newAccessToken });
+          localStorage.setItem(STORAGE_KEYS.TOKEN, newAccessToken);
+          console.log("새로운 토큰 저장:", newAccessToken);
+        } else {
+          console.error("토큰이 응답에 포함되지 않았습니다.");
+          set({ accessToken: null });
+          localStorage.removeItem(STORAGE_KEYS.TOKEN);
+        }
+      } catch (error) {
+        console.error("토큰 재발급 실패:", error);
+        set({ accessToken: null });
+        localStorage.removeItem(STORAGE_KEYS.TOKEN);
+        window.location.href = "/login"; // 로그아웃 처리
+      }
+    }, TOKEN_REFRESH_INTERVAL);
+  },
+}));


### PR DESCRIPTION
## Background
재발급 토큰 api 및 토큰 전역상태로 관리

## Details
- authStore
zustand 전역 상태 관리 도구를 사용해 토큰 관리(29분 간격)
- App
accessToken 자동 갱신 기능 추가


## Discuss


## UI Images